### PR TITLE
Continuation subclass

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -472,6 +472,7 @@ class Jacobian:
 
         buses is the buses dictionary from the load flow class
         """
+        self.reset_original_matrix()
         self.cols = self.m + 1
         self.rows = self.m + 1
         new_row = [0] * (self.m +1)


### PR DESCRIPTION
- Laget et forslag til implementering av Continuation-klassen
- subclass av Load_Flow
- initialiseringsmetode der vi kan putte inn alt av verdier
- predictor og corrector initialisering
- skall for metode som skal bestemme om det er load eller voltage parameter som skal brukes
- Resetter mismatch vector og jacobian matrix i expand-metodene slik at man ikke trenger å resette selv